### PR TITLE
Format Check をする CI を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Use npm
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          CI: true
+
+      - name: format
+        run: npm run format:check
+        env:
+          CI: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Deploy
 
 on:
   push:

--- a/index.htm
+++ b/index.htm
@@ -7901,51 +7901,106 @@
       </div>
       <div class="site-content" id="content">
         <main class="site-main" id="main">
-            <section class="section-rule onepage-section section-meta section-padding" id="rule">
-                <div class="container">
-                    <div class="section-title-area">
-                        <h1 class="section-subtitle">Overview</h1>
-                        <h1 class="section-title">概要</h1>
-                        <div class="section-desc row">
-                            <p data-mce-style="text-align: center;" style="text-align: center">
-                                4.5時間で算数 / 数学の問題をあらゆる方法で解き、その<strong>速さ</strong>と<strong>正確性</strong>を競います。
-                            </p>
-                            <p data-mce-style="text-align: center;" style="text-align: center">
-                                <strong>算数</strong>の問題を<strong>数学</strong>で、<strong>数式処理システム</strong>や<strong>プログラミング</strong>で解いて良いという日本初の数学コンテスト。
-                            </p>
-                            <p data-mce-style="text-align: center;" style="text-align: center"><span
-                                    data-mce-style="font-size: 20px;"
-                                    style="font-size: 20px"><strong>年齢、職業</strong>の制限はなく、子供から大人まで全ての方がご参加いただけます。</span>
-                            </p>
-                            <div class="row">
-                                <div class="mt-3 mx-auto col-md-4">
-                                    <div style="display: inline">
-                                        <img alt="" src="img/watch.png" style="width:20%;display:inline;">
-                                        <p
-                                                style="vertical-align: text-top;font-size: 20px;line-height: 28px;margin-bottom:0px;margin-left:16px;display:inline;">
-                                            <span style="font-size: 40px"> 4.5</span>hours
-                                        </p>
-                                    </div>
-                                </div>
-                                <div class="mx-auto mt-3 col-md-4">
-                                    <div style="display: inline">
-                                        <img alt="" src="img/browser.png" style="width:20%;display:inline;">
-                                        <p
-                                                style="vertical-align: text-top;font-size: 20px;line-height: 28px;margin-bottom:0px;margin-left:16px;display:inline;">
-                                            使用可<sup style="font-size:1px;">＊１</sup></p>
-                                    </div>
-                                </div>
-                                <div class="mt-3 mx-auto text-center col-md-4">
-                                    <div class="mx-auto">
-                                        <img alt="" src="img/group.png" style="width:20%;display:inline;">
-                                        <p
-                                                style="vertical-align: text-top;font-size: 20px;line-height: 28px;margin-left:12px;margin-bottom:0px;display:inline;">
-                                            だれでも参加可
-                                        </p>
-                                    </div>
-                                </div>
-                            </div>
-                            <!--   <p class="mt-5 mx-auto" style="text-align: center" data-mce-style="text-align: center;">
+          <section
+            class="section-rule onepage-section section-meta section-padding"
+            id="rule"
+          >
+            <div class="container">
+              <div class="section-title-area">
+                <h1 class="section-subtitle">Overview</h1>
+                <h1 class="section-title">概要</h1>
+                <div class="section-desc row">
+                  <p
+                    data-mce-style="text-align: center;"
+                    style="text-align: center"
+                  >
+                    4.5時間で算数 /
+                    数学の問題をあらゆる方法で解き、その<strong>速さ</strong>と<strong>正確性</strong>を競います。
+                  </p>
+                  <p
+                    data-mce-style="text-align: center;"
+                    style="text-align: center"
+                  >
+                    <strong>算数</strong
+                    >の問題を<strong>数学</strong>で、<strong>数式処理システム</strong>や<strong>プログラミング</strong>で解いて良いという日本初の数学コンテスト。
+                  </p>
+                  <p
+                    data-mce-style="text-align: center;"
+                    style="text-align: center"
+                  >
+                    <span
+                      data-mce-style="font-size: 20px;"
+                      style="font-size: 20px"
+                      ><strong>年齢、職業</strong
+                      >の制限はなく、子供から大人まで全ての方がご参加いただけます。</span
+                    >
+                  </p>
+                  <div class="row">
+                    <div class="mt-3 mx-auto col-md-4">
+                      <div style="display: inline">
+                        <img
+                          alt=""
+                          src="img/watch.png"
+                          style="width: 20%; display: inline"
+                        />
+                        <p
+                          style="
+                            vertical-align: text-top;
+                            font-size: 20px;
+                            line-height: 28px;
+                            margin-bottom: 0px;
+                            margin-left: 16px;
+                            display: inline;
+                          "
+                        >
+                          <span style="font-size: 40px">6</span>hours
+                        </p>
+                      </div>
+                    </div>
+                    <div class="mx-auto mt-3 col-md-4">
+                      <div style="display: inline">
+                        <img
+                          alt=""
+                          src="img/browser.png"
+                          style="width: 20%; display: inline"
+                        />
+                        <p
+                          style="
+                            vertical-align: text-top;
+                            font-size: 20px;
+                            line-height: 28px;
+                            margin-bottom: 0px;
+                            margin-left: 16px;
+                            display: inline;
+                          "
+                        >
+                          使用可<sup style="font-size: 1px">＊１</sup>
+                        </p>
+                      </div>
+                    </div>
+                    <div class="mt-3 mx-auto text-center col-md-4">
+                      <div class="mx-auto">
+                        <img
+                          alt=""
+                          src="img/group.png"
+                          style="width: 20%; display: inline"
+                        />
+                        <p
+                          style="
+                            vertical-align: text-top;
+                            font-size: 20px;
+                            line-height: 28px;
+                            margin-left: 12px;
+                            margin-bottom: 0px;
+                            display: inline;
+                          "
+                        >
+                          だれでも参加可
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                  <!--   <p class="mt-5 mx-auto" style="text-align: center" data-mce-style="text-align: center;">
                                    <a href="/rule" data-mce-href="/rule">詳細を見る</a>
                                </p> -->
                 </div>
@@ -8230,19 +8285,47 @@
                 <h1 class="section-subtitle">members</h1>
                 <h1 class="section-title">大会本部</h1>
                 <div class="row mt-5">
-                    <div class="section-desc">
-                        <table class="mce-item-table" data-mce-style="border-collapse: collapse; width: 100%; height: 260px;"
-                               style="border-collapse: collapse;width: 100%;height: 260px">
-                            <tbody>
-                            <tr data-mce-style="height: 18px;" style="height: 18px">
-                                <td style="width: 15.8236%;height: 18px;text-align: left">実行委員長</td>
-                                <td style="width: 19.40927819706499%;height: 18px;text-align: left">種村 圭依人
-                                </td>
-                                <td style="width: 64.76712180293501%;height: 18px;text-align: left">
-                                    関西学院大学総合政策学部2年生
-                                </td>
-                            </tr>
-                            <!-- <tr data-mce-style="height: 18px;" style="height: 18px">
+                  <div class="section-desc">
+                    <table
+                      class="mce-item-table"
+                      data-mce-style="border-collapse: collapse; width: 100%; height: 260px;"
+                      style="
+                        border-collapse: collapse;
+                        width: 100%;
+                        height: 260px;
+                      "
+                    >
+                      <tbody>
+                        <tr data-mce-style="height: 18px;" style="height: 18px">
+                          <td
+                            style="
+                              width: 15.8236%;
+                              height: 18px;
+                              text-align: left;
+                            "
+                          >
+                            実行委員長
+                          </td>
+                          <td
+                            style="
+                              width: 19.40927819706499%;
+                              height: 18px;
+                              text-align: left;
+                            "
+                          >
+                            種村 圭依人
+                          </td>
+                          <td
+                            style="
+                              width: 64.76712180293501%;
+                              height: 18px;
+                              text-align: left;
+                            "
+                          >
+                            関西学院大学総合政策学部2年生
+                          </td>
+                        </tr>
+                        <!-- <tr data-mce-style="height: 18px;" style="height: 18px">
                                 <td style="width: 15.8236%;height: 18px;text-align: left">実行委員</td>
                                 <td style="width: 19.40927819706499%;height: 18px;text-align: left">大日 蒼
                                 </td>
@@ -8250,7 +8333,7 @@
                                     null
                                 </td>
                             </tr> -->
-                            <!-- <tr data-mce-style="height: 18px;" style="height: 18px">
+                        <!-- <tr data-mce-style="height: 18px;" style="height: 18px">
                                 <td data-mce-style="width: 15.8236%; height: 18px; text-align: left;"
                                     style="width: 15.8236%;height: 18px;text-align: left">
                                     実行委員
@@ -8260,56 +8343,184 @@
                                     坂本 悠輔
                                 </td>
                             </tr> -->
-                            <tr data-mce-style="height: 18px;" style="height: 18px">
-                                <td style="width: 15.8236%;text-align: left;height: 18px">顧問</td>
-                                <td style="width: 19.40927819706499%;text-align: left;height: 18px">宮寺 良平
-                                </td>
-                                <td style="width: 64.76712180293501%;text-align: left;height: 18px">
-                                    啓明学院中学校高等学校理数教育アドバイザー、理学博士
-                                </td>
-                            </tr>
-                            <tr data-mce-style="height: 33px;" style="height: 33px">
-                                <td style="width: 15.8236%;text-align: left;height: 33px">顧問</td>
-                                <td style="width: 19.40927819706499%;text-align: left;height: 33px">内田 芳宏
-                                </td>
-                                <td style="width: 64.76712180293501%;text-align: left;height: 33px">
-                                    立教池袋中学校高等学校教務部長
-                                </td>
-                            </tr>
-                            <tr data-mce-style="height: 18px;" style="height: 18px">
-                                <td style="width: 15.8236%;height: 18px;text-align: left">審査員</td>
-                                <td style="width: 19.40927819706499%;height: 18px;text-align: left">巳波 弘佳
-                                </td>
-                                <td style="width: 64.76712180293501%;height: 18px;text-align: left">
-                                    関西学院大学 工学部 情報工学課程教授、副学長、情報化推進機構長、AI活用人材育成プログラム統括
-                                </td>
-                            </tr>
-                            <tr data-mce-style="height: 18px;" style="height: 18px">
-                                <td style="width: 15.8236%;height: 18px;text-align: left">審査員</td>
-                                <td style="width: 19.40927819706499%;height: 18px;text-align: left">篠原 彌一
-                                </td>
-                                <td style="width: 64.76712180293501%;height: 18px;text-align: left">
-                                    関西学院大学 名誉教授
-                                </td>
-                            </tr>
-                            <tr data-mce-style="height: 18px;" style="height: 18px">
-                                <td style="width: 15.8236%;text-align: left;height: 18px">大会顧問</td>
-                                <td style="width: 19.40927819706499%;text-align: left;height: 18px">中田 和宏
-                                </td>
-                                <td style="width: 64.76712180293501%;text-align: left;height: 18px">
-                                    関西学院高等部教諭
-                                </td>
-                            </tr>
-                            <tr data-mce-style="height: 18px;" style="height: 18px">
-                                <td style="width: 15.8236%;text-align: left;height: 18px">コーチ</td>
-                                <td style="width: 19.40927819706499%;text-align: left;height: 18px">青木 徹
-                                </td>
-                                <td style="width: 64.76712180293501%;text-align: left;height: 18px">修士(経済)
-                                </td>
-                            </tr>
-                            </tbody>
-                        </table>
-                    </div>
+                        <tr data-mce-style="height: 18px;" style="height: 18px">
+                          <td
+                            style="
+                              width: 15.8236%;
+                              text-align: left;
+                              height: 18px;
+                            "
+                          >
+                            顧問
+                          </td>
+                          <td
+                            style="
+                              width: 19.40927819706499%;
+                              text-align: left;
+                              height: 18px;
+                            "
+                          >
+                            宮寺 良平
+                          </td>
+                          <td
+                            style="
+                              width: 64.76712180293501%;
+                              text-align: left;
+                              height: 18px;
+                            "
+                          >
+                            啓明学院中学校高等学校理数教育アドバイザー、理学博士
+                          </td>
+                        </tr>
+                        <tr data-mce-style="height: 33px;" style="height: 33px">
+                          <td
+                            style="
+                              width: 15.8236%;
+                              text-align: left;
+                              height: 33px;
+                            "
+                          >
+                            顧問
+                          </td>
+                          <td
+                            style="
+                              width: 19.40927819706499%;
+                              text-align: left;
+                              height: 33px;
+                            "
+                          >
+                            内田 芳宏
+                          </td>
+                          <td
+                            style="
+                              width: 64.76712180293501%;
+                              text-align: left;
+                              height: 33px;
+                            "
+                          >
+                            立教池袋中学校高等学校教務部長
+                          </td>
+                        </tr>
+                        <tr data-mce-style="height: 18px;" style="height: 18px">
+                          <td
+                            style="
+                              width: 15.8236%;
+                              height: 18px;
+                              text-align: left;
+                            "
+                          >
+                            審査員
+                          </td>
+                          <td
+                            style="
+                              width: 19.40927819706499%;
+                              height: 18px;
+                              text-align: left;
+                            "
+                          >
+                            巳波 弘佳
+                          </td>
+                          <td
+                            style="
+                              width: 64.76712180293501%;
+                              height: 18px;
+                              text-align: left;
+                            "
+                          >
+                            関西学院大学 工学部
+                            情報工学課程教授、副学長、情報化推進機構長、AI活用人材育成プログラム統括
+                          </td>
+                        </tr>
+                        <tr data-mce-style="height: 18px;" style="height: 18px">
+                          <td
+                            style="
+                              width: 15.8236%;
+                              height: 18px;
+                              text-align: left;
+                            "
+                          >
+                            審査員
+                          </td>
+                          <td
+                            style="
+                              width: 19.40927819706499%;
+                              height: 18px;
+                              text-align: left;
+                            "
+                          >
+                            篠原 彌一
+                          </td>
+                          <td
+                            style="
+                              width: 64.76712180293501%;
+                              height: 18px;
+                              text-align: left;
+                            "
+                          >
+                            関西学院大学 名誉教授
+                          </td>
+                        </tr>
+                        <tr data-mce-style="height: 18px;" style="height: 18px">
+                          <td
+                            style="
+                              width: 15.8236%;
+                              text-align: left;
+                              height: 18px;
+                            "
+                          >
+                            大会顧問
+                          </td>
+                          <td
+                            style="
+                              width: 19.40927819706499%;
+                              text-align: left;
+                              height: 18px;
+                            "
+                          >
+                            中田 和宏
+                          </td>
+                          <td
+                            style="
+                              width: 64.76712180293501%;
+                              text-align: left;
+                              height: 18px;
+                            "
+                          >
+                            関西学院高等部教諭
+                          </td>
+                        </tr>
+                        <tr data-mce-style="height: 18px;" style="height: 18px">
+                          <td
+                            style="
+                              width: 15.8236%;
+                              text-align: left;
+                              height: 18px;
+                            "
+                          >
+                            コーチ
+                          </td>
+                          <td
+                            style="
+                              width: 19.40927819706499%;
+                              text-align: left;
+                              height: 18px;
+                            "
+                          >
+                            青木 徹
+                          </td>
+                          <td
+                            style="
+                              width: 64.76712180293501%;
+                              text-align: left;
+                              height: 18px;
+                            "
+                          >
+                            修士(経済)
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
                 </div>
                 <div class="section-content-area custom-section-content"></div>
               </div>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "contestsite",
   "version": "1.0.0",
   "scripts": {
-    "format": "prettier --write \"**/*.{js,json,css,htm,html}\""
+    "format": "prettier --write \"**/*.{js,json,css,htm,html}\"",
+    "format:check": "prettier --check \"**/*.{js,json,css,htm,html}\""
   },
   "dependencies": {
     "prettier": "^2.8.4"


### PR DESCRIPTION
## 背景

Format するのを忘れて master にマージしてしまうことがある。
Restyled などの Format を検証をする Bot があるが、CI で代替可能なので、CI でやりたい。

## 解決策

新たに `ci.yml` を追加し、PUSH 時に Format を検証するようにした。
なお CI ではあくまで Format の検証のみで、自動整形は行わない。なぜなら Prettier は普通に壊れることがあるので、自動で整形するとバグを混在するリスクがあるため。
